### PR TITLE
Replicate bio and headshot on all pages

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -59,11 +59,16 @@
     <header>
       <div class="avatar">
         <!-- Replace src with your actual headshot path -->
-        <img alt="Portrait of Israel Ben David" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><rect width='100%' height='100%' rx='48' fill='%23222'/><text x='50%' y='56%' dominant-baseline='middle' text-anchor='middle' font-family='system-ui' font-size='34' fill='white'>IB</text></svg>">
+        <img alt="Portrait of Israel Ben David" src="https://media.licdn.com/dms/image/v2/D4D03AQGsL2EC3x27pg/profile-displayphoto-shrink_800_800/B4DZgS1ASWHYAc-/0/1752662542486?e=1758758400&amp;v=beta&amp;t=hySKJwpm9S1ouAHMAu4a3dIaHR5P6971oVE0QeJ5wV8">
       </div>
       <div class="intro">
         <h1>Israel Ben David</h1>
-        <p>Software engineer focused on Machine Learning &amp; Computer Vision. I build real‑time perception tools and generative systems, and love shipping elegant, fast solutions.</p>
+        <p>
+I am a Computer Science MSc student at the School of Computer Science and Engineering at the Hebrew University of Jerusalem, under the supervision of Prof. Dani Lischinski.
+
+In addition, I work as a software engineer at Sick Sensors, specializing in computer vision for real world applications.
+
+My research interests include machine learning, computer vision, and generative models. More specifically, I am interested in developing new tools for content synthesis and controlling image generation.        </p>
         <div class="links">
           <a href="mailto:israel@example.com">Email</a>
           <a href="https://github.com/IsraelBenDavid" target="_blank" rel="noopener">GitHub</a>

--- a/education.html
+++ b/education.html
@@ -60,11 +60,16 @@
     <header>
       <div class="avatar">
         <!-- Replace src with your actual headshot path -->
-        <img alt="Portrait of Israel Ben David" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><rect width='100%' height='100%' rx='48' fill='%23222'/><text x='50%' y='56%' dominant-baseline='middle' text-anchor='middle' font-family='system-ui' font-size='34' fill='white'>IB</text></svg>">
+        <img alt="Portrait of Israel Ben David" src="https://media.licdn.com/dms/image/v2/D4D03AQGsL2EC3x27pg/profile-displayphoto-shrink_800_800/B4DZgS1ASWHYAc-/0/1752662542486?e=1758758400&amp;v=beta&amp;t=hySKJwpm9S1ouAHMAu4a3dIaHR5P6971oVE0QeJ5wV8">
       </div>
       <div class="intro">
         <h1>Israel Ben David</h1>
-        <p>Software engineer focused on Machine Learning &amp; Computer Vision. I build real‑time perception tools and generative systems, and love shipping elegant, fast solutions.</p>
+        <p>
+I am a Computer Science MSc student at the School of Computer Science and Engineering at the Hebrew University of Jerusalem, under the supervision of Prof. Dani Lischinski.
+
+In addition, I work as a software engineer at Sick Sensors, specializing in computer vision for real world applications.
+
+My research interests include machine learning, computer vision, and generative models. More specifically, I am interested in developing new tools for content synthesis and controlling image generation.        </p>
         <div class="links">
           <a href="mailto:israel@example.com">Email</a>
           <a href="https://github.com/IsraelBenDavid" target="_blank" rel="noopener">GitHub</a>

--- a/projects.html
+++ b/projects.html
@@ -59,11 +59,16 @@
     <header>
       <div class="avatar">
         <!-- Replace src with your actual headshot path -->
-        <img alt="Portrait of Israel Ben David" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='96' height='96'><rect width='100%' height='100%' rx='48' fill='%23222'/><text x='50%' y='56%' dominant-baseline='middle' text-anchor='middle' font-family='system-ui' font-size='34' fill='white'>IB</text></svg>">
+        <img alt="Portrait of Israel Ben David" src="https://media.licdn.com/dms/image/v2/D4D03AQGsL2EC3x27pg/profile-displayphoto-shrink_800_800/B4DZgS1ASWHYAc-/0/1752662542486?e=1758758400&amp;v=beta&amp;t=hySKJwpm9S1ouAHMAu4a3dIaHR5P6971oVE0QeJ5wV8">
       </div>
       <div class="intro">
         <h1>Israel Ben David</h1>
-        <p>Software engineer focused on Machine Learning &amp; Computer Vision. I build real‑time perception tools and generative systems, and love shipping elegant, fast solutions.</p>
+        <p>
+I am a Computer Science MSc student at the School of Computer Science and Engineering at the Hebrew University of Jerusalem, under the supervision of Prof. Dani Lischinski.
+
+In addition, I work as a software engineer at Sick Sensors, specializing in computer vision for real world applications.
+
+My research interests include machine learning, computer vision, and generative models. More specifically, I am interested in developing new tools for content synthesis and controlling image generation.        </p>
         <div class="links">
           <a href="mailto:israel@example.com">Email</a>
           <a href="https://github.com/IsraelBenDavid" target="_blank" rel="noopener">GitHub</a>


### PR DESCRIPTION
## Summary
- Sync education, projects, and awards pages with index header so all share the same headshot and multi-paragraph bio

## Testing
- `npm test` *(fails: ENOENT, could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac278343148327bd151f3594fc924f