### PR TITLE
Make header responsive for mobile

### DIFF
--- a/awards.html
+++ b/awards.html
@@ -51,6 +51,12 @@
     .item p{margin:8px 0 0}
 
     footer{margin-top:40px; color:var(--muted); font-size:14px}
+
+    @media (max-width: 600px) {
+      header{grid-template-columns:1fr; text-align:center}
+      .avatar{margin:0 auto}
+      .links{justify-content:center}
+    }
   </style>
 </head>
 <body>

--- a/education.html
+++ b/education.html
@@ -52,6 +52,12 @@
     .item p{margin:8px 0 0}
 
     footer{margin-top:40px; color:var(--muted); font-size:14px}
+
+    @media (max-width: 600px) {
+      header{grid-template-columns:1fr; text-align:center}
+      .avatar{margin:0 auto}
+      .links{justify-content:center}
+    }
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,12 @@
     .item p{margin:8px 0 0}
 
     footer{margin-top:40px; color:var(--muted); font-size:14px}
+
+    @media (max-width: 600px) {
+      header{grid-template-columns:1fr; text-align:center}
+      .avatar{margin:0 auto}
+      .links{justify-content:center}
+    }
   </style>
 </head>
 <body>

--- a/projects.html
+++ b/projects.html
@@ -51,6 +51,12 @@
     .item p{margin:8px 0 0}
 
     footer{margin-top:40px; color:var(--muted); font-size:14px}
+
+    @media (max-width: 600px) {
+      header{grid-template-columns:1fr; text-align:center}
+      .avatar{margin:0 auto}
+      .links{justify-content:center}
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Add mobile-specific media query to stack avatar above bio and center header content.
- Center link row on small screens to improve layout on phones.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2e426f0c8327b040a548cd6eb4a6